### PR TITLE
correct the spelling of spritz

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 module.exports = {
   async activate(count) {
     for (let i = 0; i < count; i++) {
-      console.log('Sprizz...');
+      console.log('Spritzzz...');
     }
   }
 };


### PR DESCRIPTION
Incidentally, I believe that any less than three `z`s is unacceptable. I wouldn't accept cologne from a drone that could not properly make the `zzz` sound.